### PR TITLE
Startup command incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Will also connect to devices automatically, and reverse ports.
 
 to start:
 
-`npm install && npm run`
+`npm install && npm start`
 
 to run on another port:
 


### PR DESCRIPTION
It should be *npm start* not *npm run*.  Think most people would know this but just in case.